### PR TITLE
Use node-pre-gyp to publish binaries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+environment:
+  matrix:
+  - nodejs_version: "0.10"
+    platform: x64
+  - nodejs_version: "0.10"
+    platform: x86
+  - nodejs_version: "0.12"
+    platform: x64
+  - nodejs_version: "0.12"
+    platform: x86
+  - nodejs_version: "4"
+    platform: x64
+  - nodejs_version: "4"
+    platform: x86
+  - nodejs_version: "5"
+    platform: x64
+  - nodejs_version: "5"
+    platform: x86
+  - nodejs_version: "6"
+    platform: x64
+  - nodejs_version: "6"
+    platform: x86
+
+install:
+  - where npm
+  - where node
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - for /f "delims=" %%a in ('where npm') do cd %%a\.. && npm install npm@latest
+  - for /f "delims=" %%a in ('where npm') do cd %%a\.. && npm install node-pre-gyp@latest
+  - 'if "%nodejs_version%_%platform%" == "4_x86" (npm config set -g cafile=package.json && npm config set -g strict-ssl=false)'
+
+build: off
+
+artifacts:
+  - path: 'build/stage/**/bcrypt*.tar.gz'
+  - path: package.json
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+after_test:
+  - node-pre-gyp package

--- a/bcrypt.js
+++ b/bcrypt.js
@@ -1,6 +1,10 @@
 'use strict';
 
-var bindings = require('bindings')('bcrypt_lib');
+var binary = require('node-pre-gyp');
+var path = require('path');
+var binding_path = binary.find(path.resolve(path.join(__dirname, './package.json')));
+var bindings = require(binding_path);
+
 var crypto = require('crypto');
 
 /// generate a salt (sync)

--- a/binding.gyp
+++ b/binding.gyp
@@ -17,6 +17,17 @@
           ],
         }],
       ],
+    },
+    {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "<(module_name)" ],
+      "copies": [
+        {
+          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+          "destination": "<(module_path)"
+        }
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "url": "https://github.com/ncb000gt/node.bcrypt.js/issues"
   },
   "scripts": {
-    "test": "node-gyp configure build && nodeunit test"
+    "test": "npm install --build-from-source && nodeunit test",
+    "install": "node-pre-gyp install --fallback-to-build"
   },
   "dependencies": {
     "bindings": "1.2.1",
-    "nan": "2.3.5"
+    "nan": "2.3.5",
+    "node-pre-gyp": "0.6.30"
   },
   "devDependencies": {
     "nodeunit": "~0.9.1"
@@ -49,5 +51,11 @@
     "Nate Rajlich <nathan@tootallnate.net> (https://github.com/tootallnate)",
     "Sean McArthur <sean.monstar@gmail.com> (https://github.com/seanmonstar)",
     "Fanie Oosthuysen <fanie.oosthuysen@gmail.com> (https://github.com/weareu)"
-  ]
+  ],
+  "binary": {
+    "module_name": "bcrypt_lib",
+    "module_path": "./lib/binding/",
+    "host": "https://github.com",
+    "remote_path": "/ncb000gt/node.bcrypt.js/releases/download/v{version}/"
+  }
 }


### PR DESCRIPTION
This PR adds node-pre-gyp support.

Compiling modules is a pain on Windows, since every machine needs the compiler. Downloading pre-built binaries during `npm install` is a big convenience.

I made a v0.8.2 release to test:

    npm install bcrypt@https://github.com/ksmyth/node.bcrypt.js/tarball/v0.8.2
    > bcrypt@0.8.2 install C:\Users\kevin\Documents\webgme\node_modules\bcrypt
    > node-pre-gyp install --fallback-to-build

    [bcrypt] Success: "C:\Users\kevin\Documents\webgme\node_modules\bcrypt\lib\binding\bcrypt_lib.node" is installed via remote
    bcrypt@0.8.2 node_modules\bcrypt
    ├── bindings@1.0.0
    ├── nan@1.5.0
    └── node-pre-gyp@0.6.4

The log indicates that `https://github.com/ksmyth/node.bcrypt.js/releases/download/v0.8.2/bcrypt_lib-v0.8.2-node-v11-win32-x64.tar.gz` was downloaded and installed.

If you are open to distributing binaries, publishing the binaries could be automated with e.g. appveyor.
