### PR TITLE
Update version of nan to support Node 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "bindings": "1.2.1",
-    "nan": "2.0.5"
+    "nan": "2.1.0"
   },
   "devDependencies": {
     "nodeunit": "~0.9.1"


### PR DESCRIPTION
We utilize bcrypt for a few things and I was trying to use it on Node 4.x but was unsuccessful. After a little bit of digging I found the issue to be `nan`. Once I looked at `nan` I saw that there was a new release `2.1.0` which added support for Node 4.x. I went ahead and updated the package file and it now works on Node 4.x.

This PR simply updates the dependency.