### PR TITLE
Clarified hash function salt parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,60 +64,82 @@ npm install bcrypt
 
 ### async (recommended)
 
-To hash a password:
-
 ```javascript
 var bcrypt = require('bcrypt');
-bcrypt.genSalt(10, function(err, salt) {
-    bcrypt.hash('B4c0/\/', salt, function(err, hash) {
+const saltRounds = 10;
+const somePlaintextPassword = 's0/\/\P4$$w0rD';
+const someOtherPlaintextPassword = 'not_bacon';
+```
+
+#### To hash a password:
+
+Technique 1 (generate a salt and hash on separate function calls):
+
+```javascript
+bcrypt.genSalt(saltRounds, function(err, salt) {
+    bcrypt.hash(somePlaintextPassword, salt, function(err, hash) {
         // Store hash in your password DB.
     });
 });
 ```
 
-To check a password:
+Technique 2 (auto-gen a salt and hash):
 
 ```javascript
-// Load hash from your password DB.
-bcrypt.compare('B4c0/\/', hash, function(err, res) {
-    // res == true
-});
-bcrypt.compare('not_bacon', hash, function(err, res) {
-    // res == false
+bcrypt.hash(somePlaintextPassword, saltRounds, function(err, hash) {
+  // Store hash in your password DB.
 });
 ```
 
-Auto-gen a salt and hash:
+Note that both techniques achieve the same end-result.
+
+#### To check a password:
 
 ```javascript
-bcrypt.hash('bacon', 8, function(err, hash) {
+// Load hash from your password DB.
+bcrypt.compare(somePlaintextPassword, hash, function(err, res) {
+    // res == true
+});
+bcrypt.compare(someOtherPlaintextPassword, hash, function(err, res) {
+    // res == false
 });
 ```
 
 
 ### sync
 
-To hash a password:
-
 ```javascript
 var bcrypt = require('bcrypt');
-var salt = bcrypt.genSaltSync(10);
-var hash = bcrypt.hashSync('B4c0/\/', salt);
+const saltRounds = 10;
+const somePlaintextPassword = 's0/\/\P4$$w0rD';
+const someOtherPlaintextPassword = 'not_bacon';
+```
+
+#### To hash a password:
+
+Technique 1 (generate a salt and hash on separate function calls):
+
+```javascript
+var salt = bcrypt.genSaltSync(saltRounds);
+var hash = bcrypt.hashSync(somePlaintextPassword, salt);
 // Store hash in your password DB.
 ```
 
-To check a password:
+Technique 2 (auto-gen a salt and hash):
+
+```javascript
+var hash = bcrypt.hashSync(somePlaintextPassword, saltRounds);
+// Store hash in your password DB.
+```
+
+As with async, both techniques achieve the same end-result.
+
+#### To check a password:
 
 ```javascript
 // Load hash from your password DB.
-bcrypt.compareSync('B4c0/\/', hash); // true
-bcrypt.compareSync('not_bacon', hash); // false
-```
-
-Auto-gen a salt and hash:
-
-```javascript
-var hash = bcrypt.hashSync('bacon', 8);
+bcrypt.compareSync(somePlaintextPassword, hash); // true
+bcrypt.compareSync(someOtherPlaintextPassword, hash); // false
 ```
 
 ## API
@@ -133,10 +155,10 @@ var hash = bcrypt.hashSync('bacon', 8);
       * `salt` - Second parameter to the callback providing the generated salt.
   * `hashSync(data, salt)`
     * `data` - [REQUIRED] - the data to be encrypted.
-    * `salt` - [REQUIRED] - the salt to be used in encryption.
+    * `salt` - [REQUIRED] - the salt to be used to hash the password. if specified as a number then a salt will be generated with the specified number of rounds and used (see example under **Usage**).
   * `hash(data, salt, cb)`
     * `data` - [REQUIRED] - the data to be encrypted.
-    * `salt` - [REQUIRED] - the salt to be used to hash the password. if specified as a number then a salt will be generated and used (see examples).
+    * `salt` - [REQUIRED] - the salt to be used to hash the password. if specified as a number then a salt will be generated with the specified number of rounds and used (see example under **Usage**).
     * `cb` - [REQUIRED] - a callback to be fired once the data has been encrypted. uses eio making it asynchronous.
       * `err` - First parameter to the callback detailing any errors.
       * `encrypted` - Second parameter to the callback providing the encrypted form.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npm install bcrypt
 ```javascript
 var bcrypt = require('bcrypt');
 const saltRounds = 10;
-const somePlaintextPassword = 's0/\/\P4$$w0rD';
+const myPlaintextPassword = 's0/\/\P4$$w0rD';
 const someOtherPlaintextPassword = 'not_bacon';
 ```
 
@@ -77,7 +77,7 @@ Technique 1 (generate a salt and hash on separate function calls):
 
 ```javascript
 bcrypt.genSalt(saltRounds, function(err, salt) {
-    bcrypt.hash(somePlaintextPassword, salt, function(err, hash) {
+    bcrypt.hash(myPlaintextPassword, salt, function(err, hash) {
         // Store hash in your password DB.
     });
 });
@@ -86,7 +86,7 @@ bcrypt.genSalt(saltRounds, function(err, salt) {
 Technique 2 (auto-gen a salt and hash):
 
 ```javascript
-bcrypt.hash(somePlaintextPassword, saltRounds, function(err, hash) {
+bcrypt.hash(myPlaintextPassword, saltRounds, function(err, hash) {
   // Store hash in your password DB.
 });
 ```
@@ -97,7 +97,7 @@ Note that both techniques achieve the same end-result.
 
 ```javascript
 // Load hash from your password DB.
-bcrypt.compare(somePlaintextPassword, hash, function(err, res) {
+bcrypt.compare(myPlaintextPassword, hash, function(err, res) {
     // res == true
 });
 bcrypt.compare(someOtherPlaintextPassword, hash, function(err, res) {
@@ -111,7 +111,7 @@ bcrypt.compare(someOtherPlaintextPassword, hash, function(err, res) {
 ```javascript
 var bcrypt = require('bcrypt');
 const saltRounds = 10;
-const somePlaintextPassword = 's0/\/\P4$$w0rD';
+const myPlaintextPassword = 's0/\/\P4$$w0rD';
 const someOtherPlaintextPassword = 'not_bacon';
 ```
 
@@ -121,14 +121,14 @@ Technique 1 (generate a salt and hash on separate function calls):
 
 ```javascript
 var salt = bcrypt.genSaltSync(saltRounds);
-var hash = bcrypt.hashSync(somePlaintextPassword, salt);
+var hash = bcrypt.hashSync(myPlaintextPassword, salt);
 // Store hash in your password DB.
 ```
 
 Technique 2 (auto-gen a salt and hash):
 
 ```javascript
-var hash = bcrypt.hashSync(somePlaintextPassword, saltRounds);
+var hash = bcrypt.hashSync(myPlaintextPassword, saltRounds);
 // Store hash in your password DB.
 ```
 
@@ -138,7 +138,7 @@ As with async, both techniques achieve the same end-result.
 
 ```javascript
 // Load hash from your password DB.
-bcrypt.compareSync(somePlaintextPassword, hash); // true
+bcrypt.compareSync(myPlaintextPassword, hash); // true
 bcrypt.compareSync(someOtherPlaintextPassword, hash); // false
 ```
 


### PR DESCRIPTION
Instigating issue (now closed): https://github.com/ncb000gt/node.bcrypt.js/issues/403

Overall: just tried to make things more consistent and less vague to the first-timer.

The changes included:
- Clarifying the definition of the `salt` parameter for the `hash` and `hashSync` methods in the API section.
- Referencing an actual example for the aforementioned functions in the README
- Moving the `hash` function example closer to the `genSalt`/`hash` example to make for a clearer association between the two.
- Modifications to the Usage section to make it easier for first-timers to understand (removed some ambiguities). For example, one thing I did was assign strings and number values to variables to make it clear how different functions achieve the same results with identical inputs.