### PR TITLE
update to "nan" to work with node 6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "bindings": "1.2.1",
-    "nan": "2.2.1"
+    "nan": "2.3.3"
   },
   "devDependencies": {
     "nodeunit": "~0.9.1"


### PR DESCRIPTION
`nan` 2.3.3 cannot compile against the version of V8 that ships with Node 6, so an update to the dependency version is necessary