### PR TITLE
Updated nan dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "bindings": "1.2.1",
-    "nan": "2.2.1"
+    "nan": "2.3.5"
   },
   "devDependencies": {
     "nodeunit": "~0.9.1"


### PR DESCRIPTION
Fixes issues when running on node v6.

For example, compiling with older nan can result in the following warning:

```
(node) v8::ObjectTemplate::Set() with non-primitive values is deprecated
(node) and will stop working in the next major release.
```